### PR TITLE
Update io.dreamsofcode.kanata.plist, small typo

### DIFF
--- a/kanata/macos/io.dreamsofcode.kanata.plist
+++ b/kanata/macos/io.dreamsofcode.kanata.plist
@@ -9,7 +9,7 @@
     <array>
         <string>/Users/elliott/.cargo/bin/kanata</string>
         <string>-c</string>
-        <string>/Users/elliott/.dotfiles/.config/kanata/kanata.kbd</string>
+        <string>/Users/elliott/.dotfiles/.config/kanata/kanata.kdb</string>
     </array>
 
     <key>RunAtLoad</key>


### PR DESCRIPTION
Fix the typo in `/Users/elliott/.dotfiles/.config/kanata/kanata.kbd` by changing it to `/Users/elliott/.dotfiles/.config/kanata/kanata.kdb`