### PR TITLE
Use the tap-hold hack to circumvent kanata's #422

### DIFF
--- a/kanata/linux/kanata.kbd
+++ b/kanata/linux/kanata.kbd
@@ -13,14 +13,14 @@
 
 (defalias
   escctrl (tap-hold 100 100 esc lctl)
-  a (tap-hold $tap-time $hold-time a lmet)
-  s (tap-hold $tap-time $hold-time s lalt)
-  d (tap-hold $tap-time $hold-time d lsft)
-  f (tap-hold $tap-time $hold-time f lctl)
-  j (tap-hold $tap-time $hold-time j rctl)
-  k (tap-hold $tap-time $hold-time k rsft)
-  l (tap-hold $tap-time $hold-time l ralt)
-  ; (tap-hold $tap-time $hold-time ; rmet)
+  a (multi f24 (tap-hold $tap-time $hold-time a lmet))
+  s (multi f24 (tap-hold $tap-time $hold-time s lalt))
+  d (multi f24 (tap-hold $tap-time $hold-time d lsft))
+  f (multi f24 (tap-hold $tap-time $hold-time f lctl))
+  j (multi f24 (tap-hold $tap-time $hold-time j rctl))
+  k (multi f24 (tap-hold $tap-time $hold-time k rsft))
+  l (multi f24 (tap-hold $tap-time $hold-time l ralt))
+  ; (multi f24 (tap-hold $tap-time $hold-time ; rmet))
 )
 
 (deflayer base


### PR DESCRIPTION
This is a proposal PR to include a work-around for kanata's https://github.com/jtroo/kanata/discussions/422

The problem and its fix are documented in the main kanata's documentation file for `tap-hold`: https://github.com/jtroo/kanata/blob/main/docs/config.adoc#tap-hold

I can confirm on my machine that without this work-around kanata causes weird behavior such as typing a symbol multiple times for no reasons, usually multiple times in a minute. With this work-around applied, the problematic behavior is gone.

I'm proposing this PR to help people new to kanata (and this repository) avoid problems with it out-of-the-box.