### PR TITLE
expand $HOME in systemd service file

### DIFF
--- a/kanata/linux/README.md
+++ b/kanata/linux/README.md
@@ -17,7 +17,7 @@ Description=Kanata keyboard remapper
 Documentation=https://github.com/jtroo/kanata
 
 [Service]
-Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:$HOME/.cargo/bin
+Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:%h/.cargo/bin
 Environment=DISPLAY=:0
 Type=simple
 ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'


### PR DESCRIPTION
The original script gives the error: `/usr/bin/sh: 1: exec: --cfg: not found`.

This is because `$HOME` wasn't expanded correctly in: `Environment=PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:$HOME/.cargo/bin`
Which would make `which kanata` fail in: `ExecStart=/usr/bin/sh -c 'exec $$(which kanata) --cfg $${HOME}/.config/kanata/config.kbd'`

A simple fix is to replace `$HOME` with `%h`, systemd's `$HOME` placeholder.